### PR TITLE
fix: group, user 순환 참조를 끊기 위해 user group_id optional로 변경

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,8 +31,8 @@ model User {
   name     String
   password String
 
-  group_id BigInt
-  group    Group @relation(fields: [group_id], references: [id], onDelete: Cascade)
+  group_id BigInt?
+  group    Group? @relation(fields: [group_id], references: [id], onDelete: Cascade)
 
   ownedGroup Group? @relation("GroupOwner")
 


### PR DESCRIPTION
그룹 -> 유저 필수
유저 -> 그룹 필수

서로 순환 참조하는 상황으로 둘 다 생성 불가함을 확인해서,
user의 group_id를 optional로 변경하였습니다.

* group 생성시 user 생성 후 owner_id 연결하면 될 것 같습니다.
* 우선 주형쌤 의견 듣고 수정 or 진행 하는 것으로 하겠습니다.