### PR TITLE
Fix/user group relation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,22 +19,30 @@ model Group {
   created_at         DateTime @default(now()) @db.Timestamptz(6)
   updated_at         DateTime? @updatedAt @db.Timestamptz(6)
 
-  owner_id BigInt @unique
-  owner    User   @relation("GroupOwner", fields: [owner_id], references: [id])
-
   users   User[]
   badges  Badge[]
 }
+
+model Owner {
+  id                 BigInt   @id @default(autoincrement())
+
+  user_id BigInt @unique
+  user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  group_id BigInt @unique
+  group Group @relation(fields: [group_id], references: [id], onDelete: Cascade)
+}
+
+
 
 model User {
   id       BigInt @id @default(autoincrement())
   name     String
   password String
 
-  group_id BigInt?
-  group    Group? @relation(fields: [group_id], references: [id], onDelete: Cascade)
+  group_id BigInt
+  group    Group @relation(fields: [group_id], references: [id], onDelete: Cascade)
 
-  ownedGroup Group? @relation("GroupOwner")
+  ownedOwner Owner?
 
   workoutLogs WorkoutLog[]
 }


### PR DESCRIPTION
그룹 -> 유저 필수
유저 -> 그룹 필수

위 순환참조를 끊기 위해선 둘 중 한곳의 릴레이션을 끊어야 합니다.
그래서 group쪽의 owner_id 릴레이션을 끊고,
owner 레코드를 새로 만들어서 user와 group에 릴레이션을 걸어주었습니다.

group 생성 방향
group 생성 -> user 생성 (group_id 릴레이션) -> owner 생성 (user_id, group_id 릴레이션)