### PR TITLE
feat: name, passwod validation 추가 & password 암호화 구현

### DIFF
--- a/domain/user/user.js
+++ b/domain/user/user.js
@@ -1,3 +1,5 @@
+import { BadRequestError } from "../../src/errors/customError.js";
+
 export class User {
   constructor(id, name, passowrd) {
     this.id = String(id);
@@ -12,20 +14,39 @@ export class User {
 }
 
 function validateName(name) {
+  const nameRegex = /^[a-z0-9가-힣]+$/;
+
   if (!name || name.trim().length === 0) {
-    throw new Error("nickname is required");
+    throw new BadRequestError("닉네임을 입력해 주세요");
   }
-  if (name.length > 10) {
-    throw new Error("nickname must be less than 10 characters");
+  if (/\s/.test(name)) {
+    throw new BadRequestError("닉네임에 공백은 넣을 수 없습니다");
+  }
+  if (name.length < 3 || name.length > 10) {
+    throw new BadRequestError("닉네임은 3 ~ 10자로 작성해 주세요");
+  }
+  if (!nameRegex.test(name)) {
+    throw new BadRequestError("닉네임은 한글, 영문, 숫자만 사용 가능합니다");
   }
 }
 
 function validatePassword(password) {
+  const regex =
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-={}[\]:;"'<>,.?/]).{8,20}$/;
+
   if (!password || password.trim().length === 0) {
-    throw new Error("password is required");
+    throw new BadRequestError("비밀번호를 입력해 주세요");
   }
-  if (password.lengh > 20) {
-    throw new Error("password must be less than 20 characters");
+  if (password.length < 8 || password.length > 20) {
+    throw new BadRequestError("비밀번호는 8 ~ 20자로 작성해 주세요");
+  }
+  if (!regex.test(password)) {
+    throw new BadRequestError(
+      "비밀번호는 영문 + 숫자 + 특수문자를 포함해야 합니다"
+    );
+  }
+  if (/\s/.test(password)) {
+    throw new BadRequestError("비밀번호에 공백은 넣을 수 없습니다");
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.0.0",
     "@prisma/client": "^7.0.0",
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0"


### PR DESCRIPTION
- password 암호화에 필요한 "bcrypt" package에 추가
- password 암호화 구현
- name, password validation 다양하게 추가
## name validation
- 닉네임 3~10자
- 공백 닉네임 거부
- 닉네임 한,영,숫자만 가능

## password validation
- 비밀번호 8~20자
- 영문, 숫자, 특수문자 포함 필수
- 공백 비밀번호 거부